### PR TITLE
Add functionality to set deskband minimum size

### DIFF
--- a/src/Configuration.cpp
+++ b/src/Configuration.cpp
@@ -365,6 +365,54 @@ bool Configuration::ReadDisplay(IXMLDOMNodePtr& node, Display& display)
     return true;
 }
 
+bool Configuration::ReadSettings(IXMLDOMNodePtr& node, settings_t& settings)
+{
+    IXMLDOMNamedNodeMapPtr pNamedNodeMap;
+    HRESULT hr = node->get_attributes(&pNamedNodeMap);
+    if (FAILED(hr)) {
+        return false;
+    }
+
+    long itemCount;
+    hr = pNamedNodeMap->get_length(&itemCount);
+    if (FAILED(hr)) {
+        return false;
+    }
+
+    IXMLDOMNodePtr pAttribute;
+    for (long i = 0; i < itemCount; ++i) {
+        hr = pNamedNodeMap->get_item(i, &pAttribute);
+        if (FAILED(hr)) {
+            return false;
+        }
+
+        ATL::CComBSTR nodeName;
+        hr = pAttribute->get_nodeName(&nodeName);
+        if (FAILED(hr)) {
+            return false;
+        }
+
+        VARIANT nodeValue;
+        hr = pAttribute->get_nodeValue(&nodeValue);
+        if (FAILED(hr)) {
+            return false;
+        }
+
+        bstr_t name(nodeName);
+        variant_t value(nodeValue);
+
+        if (name == bstr_t("minSizeX")) {
+            settings.MinSizeX = atoi(bstr_t(value));
+        }
+
+        if (name == bstr_t("minSizeY")) {
+            settings.MinSizeY = atoi(bstr_t(value));
+        }
+    }
+
+    return true;
+}
+
 HRESULT Configuration::GetConfigPath(std::wstring& filePath)
 {
     wchar_t path[MAX_PATH] = { 0 };
@@ -429,6 +477,8 @@ bool Configuration::Read()
                 ReadCounters(childNode, _counters);
             } else if (nodeName == "pages") {
                 ReadPages(childNode, _pages);
+            } else if (nodeName == "settings") {
+                ReadSettings(childNode, _settings);
             }
 
             IXMLDOMNodePtr nextChildNode;

--- a/src/Configuration.h
+++ b/src/Configuration.h
@@ -72,12 +72,24 @@ public:
         std::wstring Value;
     };
 
+    struct Settings {
+        int MinSizeX;
+        int MinSizeY;
+
+        Settings()
+            : MinSizeX(10)
+            , MinSizeY(10) {
+        }
+    };
+
     typedef std::unordered_map<std::wstring, Counter> counters_t;
     typedef std::vector<Page> pages_t;
+    typedef Settings settings_t;
 
 private:
     counters_t _counters;
     pages_t    _pages;
+    settings_t _settings;
 
     void Initialize();
     static bool ReadCounter(IXMLDOMNodePtr& node, Counter& counter);
@@ -87,6 +99,7 @@ private:
     static bool ReadLines(IXMLDOMNodePtr& node, std::vector<Line>& lines);
     static bool ReadLine(IXMLDOMNodePtr& node, Line& line);
     static bool ReadDisplay(IXMLDOMNodePtr& node, Display& display);
+    static bool ReadSettings(IXMLDOMNodePtr& node, settings_t& counters);
 
 public:
     static HRESULT GetConfigPath(std::wstring& configPath);
@@ -94,4 +107,5 @@ public:
 
     counters_t& GetCounters() { return _counters; }
     pages_t& GetPages() { return _pages; }
+    settings_t& GetSettings() { return _settings; }
 };

--- a/src/PerfBar.cpp
+++ b/src/PerfBar.cpp
@@ -64,11 +64,12 @@ STDMETHODIMP CPerfBar::GetBandInfo(DWORD dwBandID, DWORD dwViewMode, DESKBANDINF
     UNREFERENCED_PARAMETER(dwBandID);
     UNREFERENCED_PARAMETER(dwViewMode);
     HRESULT hr = E_FAIL;
+    Configuration::settings_t & settings = m_config.GetSettings();
 
     if (pdbi) {
         if (pdbi->dwMask & DBIM_MINSIZE) {
-            pdbi->ptMinSize.x = 10;
-            pdbi->ptMinSize.y = 10;
+            pdbi->ptMinSize.x = settings.MinSizeX;
+            pdbi->ptMinSize.y = settings.MinSizeY;
         }
 
         if (pdbi->dwMask & DBIM_MAXSIZE) {

--- a/src/config.xml
+++ b/src/config.xml
@@ -35,4 +35,6 @@
             </lines>
         </page>
     </pages>
+    <settings minSizeX="10" minSizeY="10">
+    </settings>
 </perfbar>


### PR DESCRIPTION
I love this little tool but I have a problem with it losing it's size when other apps start eating up the notification area's space. Yes, I can move PermonBar's deskband further to the left to accommodate but then it takes up unnecessary taskbar space. The more sensible way to deal with this problem is setting a minimum size that the deskband is able to shrink to. However, I was surprised that this couldn't be done at runtime and the hard-coded value of _10_ located [here](https://github.com/XhmikosR/perfmonbar/blob/master/src/PerfBar.cpp#L70-L71) is too low for my liking. This PR also creates a new XML node called _Settings_ which is where I think all global settings should reside.