### PR TITLE
Add possibility to configure minimum characters length of show value

### DIFF
--- a/src/Configuration.cpp
+++ b/src/Configuration.cpp
@@ -359,6 +359,8 @@ bool Configuration::ReadDisplay(IXMLDOMNodePtr& node, Display& display)
             display.Divide = atof(bstr_t(value));
         } else if (name == bstr_t("decimals")) {
             display.Decimals = atoi(bstr_t(value));
+        } else if (name == bstr_t("characters")) {
+            display.Characters = atoi(bstr_t(value));
         }
     }
 

--- a/src/Configuration.h
+++ b/src/Configuration.h
@@ -28,11 +28,13 @@ public:
         std::wstring Counter;
         std::wstring Prefix;
         std::wstring Suffix;
+        int          Characters;
         int          Decimals;
         double       Divide;
 
         Display()
-            : Decimals(0)
+            : Characters(0)
+            , Decimals(0)
             , Divide(0) {
         }
     };

--- a/src/PerfBar.cpp
+++ b/src/PerfBar.cpp
@@ -383,8 +383,9 @@ void CPerfBar::PaintData(HDC hdc, POINT offset)
                 swprintf_s(
                     formattingString,
                     _countof(formattingString),
-                    L"%s%d%s",
-                    L"%.",
+                    L"%s%d.%d%s",
+                    L"%",
+                    iit->Characters > 0 ? iit->Characters : 0,
                     iit->Decimals > 0 ? iit->Decimals : 0,
                     L"f"
                 );

--- a/src/config.xml
+++ b/src/config.xml
@@ -16,7 +16,8 @@
         <page offsetY="6">
             <lines>
                 <line fontFamily="Segoe UI" fontSize="8" fontItalic="false" fontBold="true" fontColor="FFFFFF">
-                    <display prefix="CPU: " suffix="% " counter="cpu"/>
+                    <!-- you can use "characters" attribute to ensure minimum length of displayed value -->
+                    <display prefix="CPU: " suffix="% " counter="cpu" characters="3"/>
                     <display prefix="· RAM: " suffix=" GB" counter="mem" decimals="2" divide="1073741824"/>
                 </line>
                 <line fontFamily="Segoe UI" fontSize="8" fontItalic="false" fontBold="true" fontColor="FFFFFF">

--- a/src/config.xml
+++ b/src/config.xml
@@ -16,8 +16,9 @@
         <page offsetY="6">
             <lines>
                 <line fontFamily="Segoe UI" fontSize="8" fontItalic="false" fontBold="true" fontColor="FFFFFF">
-                    <!-- you can use "characters" attribute to ensure minimum length of displayed value -->
-                    <display prefix="CPU: " suffix="% " counter="cpu" characters="3"/>
+                    <!-- you can use the "characters" attribute to ensure a minimum length of the displayed value -->
+                    <!-- <display prefix="CPU: " suffix="% " counter="cpu" characters="3"/> -->
+                    <display prefix="CPU: " suffix="% " counter="cpu"/>
                     <display prefix="· RAM: " suffix=" GB" counter="mem" decimals="2" divide="1073741824"/>
                 </line>
                 <line fontFamily="Segoe UI" fontSize="8" fontItalic="false" fontBold="true" fontColor="FFFFFF">


### PR DESCRIPTION
I introduced new configuration option `characters` for `display` tag, because I wanted to have option perfectly align two rows of values independently on current characters length of shown value. Default value is 0 which means no padding at all (like until now).

Before:
![Screenshot](https://i.imgur.com/SjmDFFH.png)
After:
![Screenshot](https://i.imgur.com/a08HiRa.png)

Fixes #23