### PR TITLE
Add possibility to configure decimal division of show value

### DIFF
--- a/src/Configuration.cpp
+++ b/src/Configuration.cpp
@@ -356,7 +356,7 @@ bool Configuration::ReadDisplay(IXMLDOMNodePtr& node, Display& display)
         } else if (name == bstr_t("counter")) {
             display.Counter = bstr_t(value);
         } else if (name == bstr_t("divide")) {
-            display.Divide = atoi(bstr_t(value));
+            display.Divide = atof(bstr_t(value));
         } else if (name == bstr_t("decimals")) {
             display.Decimals = atoi(bstr_t(value));
         }

--- a/src/Configuration.h
+++ b/src/Configuration.h
@@ -29,7 +29,7 @@ public:
         std::wstring Prefix;
         std::wstring Suffix;
         int          Decimals;
-        int          Divide;
+        double       Divide;
 
         Display()
             : Decimals(0)


### PR DESCRIPTION
I changed configuration option `Divide` to double because I wanted to show current CPU frequency, but it cannot be done directly from CPU frequency counter. It must be done from CPU performance percentage and CPU base frequency as show [here](https://stackoverflow.com/questions/61802420/unable-to-get-current-cpu-frequency-in-powershell-or-python/61808781#61808781). So value must be divided by `100 / base CPU frequency` which in almost all cases will be decimal number. Currently any division number is converted to integer which leads to inaccurate results.